### PR TITLE
Generic-only new operations

### DIFF
--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1071,6 +1071,15 @@ equivalent to, and potentially more efficient than, `And(m, IsNaN(v));` etc.
     <code>M **MaskedIsNaN**(M m, V v)</code>: returns mask indicating whether
     `v[i]` is "not a number" (unordered) or `false` if `m[i]` is false.
 
+*   `V`: `{f}` \
+    <code>M **MaskedIsInf**(M m, V v)</code>: returns mask indicating whether
+    `v[i]` is positive or negative infinity or `false` if `m[i]` is false.
+
+*   `V`: `{f}` \
+    <code>M **MaskedIsFinite**(M m, V v)</code>: returns mask indicating whether
+    `v[i]` is neither NaN nor infinity, i.e. normal, subnormal or zero or
+    `false` if `m[i]` is false. Equivalent to `Not(Or(IsNaN(v), IsInf(v)))`.
+
 ### Logical
 
 *   `V`: `{u,i}` \

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -1910,6 +1910,17 @@ obtain the `D` that describes the return type.
     <code>Vec&lt;D&gt; **DemoteTo**(D, V v)</code>: narrows float to half (for
     bf16, it is unspecified whether this truncates or rounds).
 
+*   `V`,`D`: (`f64,i32`), (`f32,f16`) \
+    <code>Vec&lt;D&gt; **DemoteCeilTo**(D, V v)</code>: Demotes a floating point
+    number to half-sized integral type with ceiling rounding.
+
+*   `V`,`D`: (`f64,i32`), (`f32,f16`) \
+    <code>Vec&lt;D&gt; **DemoteFloorTo**(D, V v)</code>: Demotes a floating
+    point number to half-sized integral type with floor rounding.
+
+*   <code>Vec&lt;D&gt; **MaskedDemoteTo**(M m, D d, V v)</code>: returns `v[i]`
+    demoted to `D` where m is active and returns zero otherwise.
+
 #### Single vector promotion
 
 These functions promote a half vector to a full vector. To obtain halves, use
@@ -1935,6 +1946,27 @@ These functions promote a half vector to a full vector. To obtain halves, use
     towards zero and converts the rounded value to a 64-bit signed or unsigned
     integer. Returns an implementation-defined value if the input exceeds the
     destination range.
+
+*   `V`: `f`, `D`:`{u,i,f}`\
+    <code>Vec&lt;D&gt; **PromoteCeilTo**(D, V part)</code>: rounds `part[i]`
+    up and converts the rounded value to a signed or unsigned integer.
+    Returns an implementation-defined value if the input exceeds the
+    destination range.
+
+*   `V`: `f`, `D`:`{u,i,f}`\
+    <code>Vec&lt;D&gt; **PromoteFloorTo**(D, V part)</code>: rounds `part[i]`
+    down and converts the rounded value to a signed or unsigned integer.
+    Returns an implementation-defined value if the input exceeds the
+    destination range.
+
+*   `V`: `f`, `D`:`{u,i,f}`\
+    <code>Vec&lt;D&gt; **PromoteToNearestInt **(D, V part)</code>: rounds
+    `part[i]` towards the nearest integer, with ties to even, and converts the
+    rounded value to a signed or unsigned integer. Returns an
+    implementation-defined value if the input exceeds the destination range.
+
+*   <code>Vec&lt;D&gt; **MaskedPromoteTo**(M m, D d, V v)</code>: returns `v[i]`
+    widened to `D` where m is active and returns zero otherwise.
 
 The following may be more convenient or efficient than also calling `LowerHalf`
 / `UpperHalf`:

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -2236,6 +2236,12 @@ Ops in this section are only available if `HWY_TARGET != HWY_SCALAR`:
     `InterleaveOdd(d, a, b)` is usually more efficient than `OddEven(b,
     DupOdd(a))`.
 
+*   <code>V **MaskedInterleaveEven**(M m, V a, V b)</code>: Performs the same
+    operation as InterleaveEven, but returns zero in lanes where `m[i]` is false.
+
+*   <code>V **MaskedInterleaveOdd**(M m, V a, V b)</code>: Performs the same
+    operation as InterleaveOdd, but returns zero in lanes where `m[i]` is false.
+
 #### Zip
 
 *   `Ret`: `MakeWide<T>`; `V`: `{u,i}{8,16,32}` \

--- a/g3doc/quick_reference.md
+++ b/g3doc/quick_reference.md
@@ -2383,6 +2383,22 @@ The following `ReverseN` must not be called if `Lanes(D()) < N`:
     must be in the range `[0, 2 * Lanes(d))` but need not be unique. The index
     type `TI` must be an integer of the same size as `TFromD<D>`.
 
+*   <code>V **MaskedTableLookupLanesOr**(V no, M m, V a, unspecified)</code> returns the
+    result of `TableLookupLanes(a, unspecified)` where `m[i]` is true, and returns
+    `no[i]` where `m[i]` is false.
+
+*   <code>V **MaskedTableLookupLanes**(M m, V a, unspecified)</code> returns
+    the result of `TableLookupLanes(a, unspecified)` where `m[i]` is true, and
+    returns zero where `m[i]` is false.
+
+*   <code>V **MaskedTwoTablesLookupLanesOr**(D d, M m, V a, V b, unspecified)</code>
+    returns the result of `TwoTablesLookupLanes(V a, V b, unspecified)` where
+    `m[i]` is true, and `a[i]` where `m[i]` is false.
+
+*   <code>V **MaskedTwoTablesLookupLanes**(D d, M m, V a, V b, unspecified)</code>
+    returns the result of `TwoTablesLookupLanes(V a, V b, unspecified)` where
+    `m[i]` is true, and zero where `m[i]` is false.
+
 *   <code>V **Per4LaneBlockShuffle**&lt;size_t kIdx3, size_t kIdx2, size_t
     kIdx1, size_t kIdx0&gt;(V v)</code> does a per 4-lane block shuffle of `v`
     if `Lanes(DFromV<V>())` is greater than or equal to 4 or a shuffle of the

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -661,6 +661,25 @@ HWY_API V MaskedSatSubOr(V no, M m, V a, V b) {
 }
 #endif  // HWY_NATIVE_MASKED_ARITH
 
+// ------------------------------ MaskedIsInf/MaskedIsFinite
+#if (defined(HWY_NATIVE_MASKED_IS_INF) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_MASKED_IS_INF
+#undef HWY_NATIVE_MASKED_IS_INF
+#else
+#define HWY_NATIVE_MASKED_IS_INF
+#endif
+
+template <class V, class M, class D = DFromV<V>>
+HWY_API MFromD<D> MaskedIsInf(const M m, const V v) {
+  return And(m, IsInf(v));
+}
+
+template <class V, class M, class D = DFromV<V>>
+HWY_API MFromD<D> MaskedIsFinite(const M m, const V v) {
+  return And(m, IsFinite(v));
+}
+#endif  // HWY_NATIVE_MASKED_IS_INF
+
 // ------------------------------ MaskedEq etc.
 #if (defined(HWY_NATIVE_MASKED_COMP) == defined(HWY_TARGET_TOGGLE))
 #ifdef HWY_NATIVE_MASKED_COMP

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -3389,6 +3389,19 @@ HWY_API VFromD<D> DemoteTo(D df16, VFromD<Rebind<float, D>> v) {
 
 #endif  // HWY_NATIVE_F16C
 
+// ------------------------------ PromoteTo F16->I
+#if HWY_HAVE_FLOAT16 || HWY_IDE
+template <class D, HWY_IF_NOT_FLOAT_D(D), HWY_IF_T_SIZE_D(D, sizeof(float))>
+HWY_API VFromD<D> PromoteTo(D d, VFromD<Rebind<float16_t, D>> v) {
+  return ConvertTo(d, PromoteTo(Rebind<float, D>(), v));
+}
+
+template <class D, HWY_IF_NOT_FLOAT_D(D), HWY_IF_T_SIZE_GT_D(D, sizeof(float))>
+HWY_API VFromD<D> PromoteTo(D d, VFromD<Rebind<float16_t, D>> v) {
+  return PromoteTo(d, PromoteTo(Rebind<float, D>(), v));
+}
+#endif
+
 // ------------------------------ F64->F16 DemoteTo
 #if (defined(HWY_NATIVE_DEMOTE_F64_TO_F16) == defined(HWY_TARGET_TOGGLE))
 #ifdef HWY_NATIVE_DEMOTE_F64_TO_F16
@@ -3522,6 +3535,53 @@ HWY_API VFromD<D> ReorderDemote2To(D dbf16, VFromD<Repartition<float, D>> a,
 
 #endif  // HWY_NATIVE_DEMOTE_F32_TO_BF16
 
+// ------------------------------ DemoteTo (Alternate Rounding)
+#if (defined(HWY_NATIVE_DEMOTE_CEIL_TO) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_DEMOTE_CEIL_TO
+#undef HWY_NATIVE_DEMOTE_CEIL_TO
+#else
+#define HWY_NATIVE_DEMOTE_CEIL_TO
+#endif
+
+#if HWY_HAVE_FLOAT64
+template <class D32, HWY_IF_UI32_D(D32)>
+HWY_API VFromD<D32> DemoteCeilTo(D32 d32, VFromD<Rebind<double, D32>> v) {
+  return DemoteTo(d32, Ceil(v));
+}
+#endif  // HWY_HAVE_FLOAT64
+
+#if HWY_HAVE_FLOAT16
+template <class D16, HWY_IF_F16_D(D16)>
+HWY_API VFromD<D16> DemoteCeilTo(D16 d16, VFromD<Rebind<float, D16>> v) {
+  return DemoteTo(d16, Ceil(v));
+}
+#endif  // HWY_HAVE_FLOAT16
+
+#endif  // HWY_NATIVE_DEMOTE_CEIL_TO
+
+#if (defined(HWY_NATIVE_DEMOTE_FLOOR_TO) == defined(HWY_TARGET_TOGGLE))
+#ifdef HWY_NATIVE_DEMOTE_FLOOR_TO
+#undef HWY_NATIVE_DEMOTE_FLOOR_TO
+#else
+#define HWY_NATIVE_DEMOTE_FLOOR_TO
+#endif
+
+#if HWY_HAVE_FLOAT64
+template <class D32, HWY_IF_UI32_D(D32)>
+HWY_API VFromD<D32> DemoteFloorTo(D32 d32, VFromD<Rebind<double, D32>> v) {
+  return DemoteTo(d32, Floor(v));
+}
+#endif  // HWY_HAVE_FLOAT64
+
+#if HWY_HAVE_FLOAT16
+template <class D16, HWY_IF_F16_D(D16)>
+HWY_API VFromD<D16> DemoteFloorTo(D16 d16, VFromD<Rebind<float, D16>> v) {
+  return DemoteTo(d16, Floor(v));
+}
+#endif  // HWY_HAVE_FLOAT16
+
+#endif  // HWY_NATIVE_DEMOTE_FLOOR_TO
+
 // ------------------------------ PromoteInRangeTo
 #if (defined(HWY_NATIVE_F32_TO_UI64_PROMOTE_IN_RANGE_TO) == \
      defined(HWY_TARGET_TOGGLE))
@@ -3652,6 +3712,24 @@ HWY_API VFromD<D> PromoteInRangeOddTo(D d, V v) {
 #endif
 }
 #endif  // HWY_TARGET != HWY_SCALAR
+
+// ------------------------------ PromoteCeilTo
+template <class DTo, class V, HWY_IF_FLOAT_V(V)>
+HWY_API Vec<DTo> PromoteCeilTo(DTo d, V v) {
+  return PromoteTo(d, Ceil(v));
+}
+
+// ------------------------------ PromoteFloorTo
+template <class DTo, class V, HWY_IF_FLOAT_V(V)>
+HWY_API Vec<DTo> PromoteFloorTo(DTo d, V v) {
+  return PromoteTo(d, Floor(v));
+}
+
+// ------------------------------ PromoteToNearestInt
+template <class DTo, class V, HWY_IF_FLOAT_V(V)>
+HWY_API Vec<DTo> PromoteToNearestInt(DTo d, V v) {
+  return PromoteTo(d, Round(v));
+}
 
 // ------------------------------ SumsOf2
 
@@ -4602,6 +4680,18 @@ HWY_API V MulSubAdd(V mul, V x, V sub_or_add) {
 template <class D, class V, class M>
 HWY_API VFromD<D> MaskedConvertTo(M m, D d, V v) {
   return IfThenElseZero(m, ConvertTo(d, v));
+}
+
+// ------------------------------ MaskedPromoteTo
+template <class D, class V, class M>
+HWY_API VFromD<D> MaskedPromoteTo(M m, D d, V v) {
+  return IfThenElseZero(m, PromoteTo(d, v));
+}
+
+// ------------------------------ MaskedDemoteTo
+template <class D, class V, class M>
+HWY_API VFromD<D> MaskedDemoteTo(M m, D d, V v) {
+  return IfThenElseZero(m, DemoteTo(d, v));
 }
 
 // ------------------------------ Integer division

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -6803,6 +6803,30 @@ HWY_API V ReverseBits(V v) {
 }
 #endif  // HWY_NATIVE_REVERSE_BITS_UI16_32_64
 
+// ------------------------------ MaskedTableLookupLanesOr
+template <class V, class M>
+HWY_API V MaskedTableLookupLanesOr(V no, M m, V a, IndicesFromD<DFromV<V>> idx) {
+  return IfThenElse(m, TableLookupLanes(a, idx), no);
+}
+
+// ------------------------------ MaskedTableLookupLanes
+template <class V, class M>
+HWY_API V MaskedTableLookupLanes(M m, V a, IndicesFromD<DFromV<V>> idx) {
+  return IfThenElseZero(m, TableLookupLanes(a, idx));
+}
+
+// ------------------------------ TwoTablesLookupLanesOr
+template <class D, class V, class M>
+HWY_API V MaskedTwoTablesLookupLanesOr(D d, M m, V a, V b, IndicesFromD<D> idx) {
+  return IfThenElse(m, TwoTablesLookupLanes(d, a, b, idx), a);
+}
+
+// ------------------------------ TwoTablesLookupLanesOrZero
+template <class D, class V, class M>
+HWY_API V MaskedTwoTablesLookupLanes(D d, M m, V a, V b, IndicesFromD<D> idx) {
+  return IfThenElse(m, TwoTablesLookupLanes(d, a, b, idx), Zero(d));
+}
+
 // ------------------------------ Per4LaneBlockShuffle
 
 #if (defined(HWY_NATIVE_PER4LANEBLKSHUF_DUP32) == defined(HWY_TARGET_TOGGLE))

--- a/hwy/ops/generic_ops-inl.h
+++ b/hwy/ops/generic_ops-inl.h
@@ -518,6 +518,24 @@ HWY_API V InterleaveEven(V a, V b) {
 }
 #endif
 
+// ------------------------------ MaskedInterleaveEven
+
+#if HWY_TARGET != HWY_SCALAR || HWY_IDE
+template <class V, class M>
+HWY_API V MaskedInterleaveEven(M m, V a, V b) {
+  return IfThenElseZero(m, InterleaveEven(DFromV<V>(), a, b));
+}
+#endif
+
+// ------------------------------ MaskedInterleaveOdd
+
+#if HWY_TARGET != HWY_SCALAR || HWY_IDE
+template <class V, class M>
+HWY_API V MaskedInterleaveOdd(M m, V a, V b) {
+  return IfThenElseZero(m, InterleaveOdd(DFromV<V>(), a, b));
+}
+#endif
+
 // ------------------------------ MinMagnitude/MaxMagnitude
 
 #if (defined(HWY_NATIVE_FLOAT_MIN_MAX_MAGNITUDE) == defined(HWY_TARGET_TOGGLE))

--- a/hwy/tests/blockwise_test.cc
+++ b/hwy/tests/blockwise_test.cc
@@ -274,12 +274,72 @@ struct TestInterleaveOdd {
   }
 };
 
+struct TestMaskedInterleaveEven {
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const size_t N = Lanes(d);
+    const MFromD<D> first_3 = FirstN(d, 3);
+    auto even_lanes = AllocateAligned<T>(N);
+    auto odd_lanes = AllocateAligned<T>(N);
+    auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(even_lanes && odd_lanes && expected);
+    for (size_t i = 0; i < N; ++i) {
+      even_lanes[i] = ConvertScalarTo<T>(2 * i + 0);
+      odd_lanes[i] = ConvertScalarTo<T>(2 * i + 1);
+    }
+    const auto even = Load(d, even_lanes.get());
+    const auto odd = Load(d, odd_lanes.get());
+
+    for (size_t i = 0; i < N; ++i) {
+      if (i < 3) {
+        expected[i] = ConvertScalarTo<T>(2 * i - (i & 1));
+      } else {
+        expected[i] = ConvertScalarTo<T>(0);
+      }
+    }
+
+    HWY_ASSERT_VEC_EQ(d, expected.get(),
+                      MaskedInterleaveEven(first_3, even, odd));
+  }
+};
+
+struct TestMaskedInterleaveOdd {
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    const size_t N = Lanes(d);
+    const MFromD<D> first_3 = FirstN(d, 3);
+    auto even_lanes = AllocateAligned<T>(N);
+    auto odd_lanes = AllocateAligned<T>(N);
+    auto expected = AllocateAligned<T>(N);
+    HWY_ASSERT(even_lanes && odd_lanes && expected);
+    for (size_t i = 0; i < N; ++i) {
+      even_lanes[i] = ConvertScalarTo<T>(2 * i + 0);
+      odd_lanes[i] = ConvertScalarTo<T>(2 * i + 1);
+    }
+    const auto even = Load(d, even_lanes.get());
+    const auto odd = Load(d, odd_lanes.get());
+
+    for (size_t i = 0; i < N; ++i) {
+      if (i < 3) {
+        expected[i] = ConvertScalarTo<T>((2 * i) - (i & 1) + 2);
+      } else {
+        expected[i] = ConvertScalarTo<T>(0);
+      }
+    }
+
+    HWY_ASSERT_VEC_EQ(d, expected.get(),
+                      MaskedInterleaveOdd(first_3, even, odd));
+  }
+};
+
 HWY_NOINLINE void TestAllInterleave() {
   // Not DemoteVectors because this cannot be supported by HWY_SCALAR.
   ForAllTypes(ForShrinkableVectors<TestInterleaveLower>());
   ForAllTypes(ForShrinkableVectors<TestInterleaveUpper>());
   ForAllTypes(ForShrinkableVectors<TestInterleaveEven>());
   ForAllTypes(ForShrinkableVectors<TestInterleaveOdd>());
+  ForAllTypes(ForShrinkableVectors<TestMaskedInterleaveEven>());
+  ForAllTypes(ForShrinkableVectors<TestMaskedInterleaveOdd>());
 }
 
 struct TestZipLower {

--- a/hwy/tests/compare_test.cc
+++ b/hwy/tests/compare_test.cc
@@ -787,15 +787,23 @@ struct TestMaskedFloatClassification {
 
     // Test against all zeros
     HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsNaN(mask_true, v0));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsInf(mask_true, v0));
+    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedIsFinite(mask_true, v0));
 
     // Test against finite values
     HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsNaN(mask_true, v1));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsInf(mask_true, v1));
+    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedIsFinite(mask_true, v1));
 
     // Test against infinite values
     HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsNaN(mask_true, v2));
+    HWY_ASSERT_MASK_EQ(d, mask_true, MaskedIsInf(mask_true, v2));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsFinite(mask_true, v2));
 
     // Test against NaN values
     HWY_ASSERT_MASK_EQ(d, mask_true, MaskedIsNaN(mask_true, v3));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsInf(mask_true, v3));
+    HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsFinite(mask_true, v3));
 
     auto bool_lanes = AllocateAligned<T>(N);
     HWY_ASSERT(bool_lanes);
@@ -810,15 +818,23 @@ struct TestMaskedFloatClassification {
 
       // Test against all zeros
       HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsNaN(mask, v0));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsInf(mask, v0));
+      HWY_ASSERT_MASK_EQ(d, mask, MaskedIsFinite(mask, v0));
 
       // Test against finite values
       HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsNaN(mask, v1));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsInf(mask, v1));
+      HWY_ASSERT_MASK_EQ(d, mask, MaskedIsFinite(mask, v1));
 
       // Test against infinite values
       HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsNaN(mask, v2));
+      HWY_ASSERT_MASK_EQ(d, mask, MaskedIsInf(mask, v2));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsFinite(mask, v2));
 
       // Test against NaN values
       HWY_ASSERT_MASK_EQ(d, mask, MaskedIsNaN(mask, v3));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsInf(mask, v3));
+      HWY_ASSERT_MASK_EQ(d, mask_false, MaskedIsFinite(mask, v3));
     }
   }
 };

--- a/hwy/tests/convert_test.cc
+++ b/hwy/tests/convert_test.cc
@@ -147,6 +147,151 @@ HWY_NOINLINE void TestAllPromoteTo() {
 }
 
 template <typename ToT>
+struct TestPromoteRoundTo {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D from_d) {
+    static_assert(sizeof(T) < sizeof(ToT), "Input type must be narrower");
+    const Rebind<ToT, D> to_d;
+
+    const size_t N = Lanes(from_d);
+    auto from = AllocateAligned<T>(N);
+    auto expected_ceil = AllocateAligned<ToT>(N);
+    auto expected_floor = AllocateAligned<ToT>(N);
+    auto expected_nearest_int = AllocateAligned<ToT>(N);
+    HWY_ASSERT(from && expected_ceil && expected_floor && expected_nearest_int);
+
+    RandomState rng;
+    for (size_t rep = 0; rep < AdjustedReps(200); ++rep) {
+      for (size_t i = 0; i < N; ++i) {
+        const uint64_t bits = rng();
+        CopyBytes<sizeof(T)>(&bits, &from[i]);  // not same size
+        expected_ceil[i] =
+            ConvertScalarTo<ToT>(std::ceil(static_cast<float>(from[i])));
+        expected_floor[i] =
+            ConvertScalarTo<ToT>(std::floor(static_cast<float>(from[i])));
+        expected_nearest_int[i] =
+            ConvertScalarTo<ToT>(std::nearbyint(static_cast<float>(from[i])));
+      }
+
+      auto input = Load(from_d, from.get());
+      auto output_ceil = PromoteCeilTo(to_d, input);
+      auto output_floor = PromoteFloorTo(to_d, input);
+      auto output_nearest_int = PromoteToNearestInt(to_d, input);
+
+      HWY_ASSERT_VEC_EQ(to_d, expected_ceil.get(), output_ceil);
+      HWY_ASSERT_VEC_EQ(to_d, expected_floor.get(), output_floor);
+      HWY_ASSERT_VEC_EQ(to_d, expected_nearest_int.get(), output_nearest_int);
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllPromoteRoundTo() {
+#if HWY_HAVE_FLOAT16
+  const ForPromoteVectors<TestPromoteRoundTo<int32_t>, 1> to_i32div2;
+  to_i32div2(hwy::float16_t());
+
+  const ForPromoteVectors<TestPromoteRoundTo<float>, 1> to_f32div2;
+  to_f32div2(hwy::float16_t());
+#endif  // HWY_HAVE_FLOAT16
+
+#if HWY_HAVE_FLOAT64
+  const ForPromoteVectors<TestPromoteRoundTo<double>, 1> to_f64div2;
+  to_f64div2(float());
+#endif  // HWY_HAVE_FLOAT64
+}
+
+template <typename ToT>
+struct TestMaskedPromoteTo {
+  template <class T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D d) {
+    static_assert(sizeof(T) < sizeof(ToT), "Input type must be narrower");
+    const Rebind<ToT, D> to_d;
+
+    const size_t N = Lanes(d);
+    auto expected = AllocateAligned<ToT>(N);
+    auto bool_lanes = AllocateAligned<ToT>(N);
+    HWY_ASSERT(expected && bool_lanes);
+
+    const auto v1 = Iota(d, 5);
+
+    RandomState rng;
+
+    for (size_t rep = 0; rep < AdjustedReps(200); ++rep) {
+      for (size_t i = 0; i < N; ++i) {
+        bool_lanes[i] = (Random32(&rng) & 1024) ? T(1) : T(0);
+
+        if (bool_lanes[i]) {
+          expected[i] = ConvertScalarTo<T>(i + 5);
+        } else {
+          expected[i] = ConvertScalarTo<T>(0);
+        }
+      }
+
+      const auto mask_i = Load(to_d, bool_lanes.get());
+      const auto mask = RebindMask(to_d, Gt(mask_i, Zero(to_d)));
+
+      HWY_ASSERT_VEC_EQ(to_d, expected.get(),
+                        MaskedPromoteTo(mask, to_d, v1));
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllMaskedPromoteTo() {
+  const ForPromoteVectors<TestMaskedPromoteTo<uint16_t>, 1> to_u16div2;
+  to_u16div2(uint8_t());
+
+  const ForPromoteVectors<TestMaskedPromoteTo<uint32_t>, 2> to_u32div4;
+  to_u32div4(uint8_t());
+
+  const ForPromoteVectors<TestMaskedPromoteTo<uint32_t>, 1> to_u32div2;
+  to_u32div2(uint16_t());
+
+  const ForPromoteVectors<TestMaskedPromoteTo<int16_t>, 1> to_i16div2;
+  to_i16div2(uint8_t());
+  to_i16div2(int8_t());
+
+  const ForPromoteVectors<TestMaskedPromoteTo<int32_t>, 1> to_i32div2;
+  to_i32div2(uint16_t());
+  to_i32div2(int16_t());
+
+  const ForPromoteVectors<TestMaskedPromoteTo<int32_t>, 2> to_i32div4;
+  to_i32div4(uint8_t());
+  to_i32div4(int8_t());
+
+  // Must test f16/bf16 separately because we can only load/store/convert them.
+
+#if HWY_HAVE_INTEGER64
+  const ForPromoteVectors<TestMaskedPromoteTo<uint64_t>, 1> to_u64div2;
+  to_u64div2(uint32_t());
+
+  const ForPromoteVectors<TestMaskedPromoteTo<int64_t>, 1> to_i64div2;
+  to_i64div2(int32_t());
+  to_i64div2(uint32_t());
+
+  const ForPromoteVectors<TestMaskedPromoteTo<uint64_t>, 2> to_u64div4;
+  to_u64div4(uint16_t());
+
+  const ForPromoteVectors<TestMaskedPromoteTo<int64_t>, 2> to_i64div4;
+  to_i64div4(int16_t());
+  to_i64div4(uint16_t());
+
+  const ForPromoteVectors<TestMaskedPromoteTo<uint64_t>, 3> to_u64div8;
+  to_u64div8(uint8_t());
+
+  const ForPromoteVectors<TestMaskedPromoteTo<int64_t>, 3> to_i64div8;
+  to_i64div8(int8_t());
+  to_i64div8(uint8_t());
+#endif
+
+#if HWY_HAVE_FLOAT64
+  const ForPromoteVectors<TestMaskedPromoteTo<double>, 1> to_f64div2;
+  to_f64div2(int32_t());
+  to_f64div2(uint32_t());
+  to_f64div2(float());
+#endif
+}
+
+template <typename ToT>
 struct TestPromoteUpperLowerTo {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D from_d) {
@@ -1556,6 +1701,8 @@ namespace {
 HWY_BEFORE_TEST(HwyConvertTest);
 HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllRebind);
 HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllPromoteTo);
+HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllPromoteRoundTo);
+HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllMaskedPromoteTo);
 HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllPromoteUpperLowerTo);
 HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllPromoteOddEvenTo);
 HWY_EXPORT_AND_TEST_P(HwyConvertTest, TestAllF16);

--- a/hwy/tests/demote_test.cc
+++ b/hwy/tests/demote_test.cc
@@ -144,6 +144,107 @@ HWY_NOINLINE void TestAllDemoteToMixed() {
 }
 
 template <typename ToT>
+struct TestMaskedDemoteToInt {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D from_d) {
+    static_assert(!IsFloat<ToT>(), "Use TestDemoteToFloat for float output");
+    static_assert(sizeof(T) > sizeof(ToT), "Input type must be wider");
+    const Rebind<ToT, D> to_d;
+
+    const size_t N = Lanes(from_d);
+    auto from = AllocateAligned<T>(N);
+    auto expected = AllocateAligned<ToT>(N);
+    auto bool_lanes = AllocateAligned<ToT>(N);
+    HWY_ASSERT(from && expected && bool_lanes);
+    // Narrower range in the wider type, for clamping before we cast
+    const T min = ConvertScalarTo<T>(IsSigned<T>() ? LimitsMin<ToT>()
+                                                   : static_cast<ToT>(0));
+    const T max = LimitsMax<ToT>();
+    RandomState rng;
+    for (size_t rep = 0; rep < AdjustedReps(200); ++rep) {
+      for (size_t i = 0; i < N; ++i) {
+        const uint64_t bits = rng();
+        CopyBytes<sizeof(T)>(&bits, &from[i]);  // not same size
+
+        bool_lanes[i] = (Random32(&rng) & 1024) ? ToT(1) : ToT(0);
+        if (bool_lanes[i]) {
+          expected[i] = static_cast<ToT>(HWY_MIN(HWY_MAX(min, from[i]), max));
+
+        } else {
+          expected[i] = ConvertScalarTo<ToT>(0);
+        }
+      }
+
+      const auto mask_i = Load(to_d, bool_lanes.get());
+      const auto mask = RebindMask(to_d, Gt(mask_i, Zero(to_d)));
+
+      const auto v1 = Load(from_d, from.get());
+
+      HWY_ASSERT_VEC_EQ(to_d, expected.get(),
+                        MaskedDemoteTo(mask, to_d, v1));
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllMaskedDemoteToInt() {
+  const ForDemoteVectors<TestMaskedDemoteToInt<uint8_t>> from_i16_to_u8;
+  from_i16_to_u8(int16_t());
+  from_i16_to_u8(uint16_t());
+
+  const ForDemoteVectors<TestMaskedDemoteToInt<int8_t>> from_i16_to_i8;
+  from_i16_to_i8(int16_t());
+  from_i16_to_i8(uint16_t());
+
+  const ForDemoteVectors<TestMaskedDemoteToInt<uint8_t>, 2>
+      from_i32_to_u8;
+  from_i32_to_u8(int32_t());
+  from_i32_to_u8(uint32_t());
+
+  const ForDemoteVectors<TestMaskedDemoteToInt<int8_t>, 2> from_i32_to_i8;
+  from_i32_to_i8(int32_t());
+  from_i32_to_i8(uint32_t());
+
+#if HWY_HAVE_INTEGER64
+  const ForDemoteVectors<TestMaskedDemoteToInt<uint8_t>, 3>
+      from_i64_to_u8;
+  from_i64_to_u8(int64_t());
+  from_i64_to_u8(uint64_t());
+
+  const ForDemoteVectors<TestMaskedDemoteToInt<int8_t>, 3> from_i64_to_i8;
+  from_i64_to_i8(int64_t());
+  from_i64_to_i8(uint64_t());
+#endif
+
+  const ForDemoteVectors<TestMaskedDemoteToInt<uint16_t>> from_i32_to_u16;
+  from_i32_to_u16(int32_t());
+  from_i32_to_u16(uint32_t());
+
+  const ForDemoteVectors<TestMaskedDemoteToInt<int16_t>> from_i32_to_i16;
+  from_i32_to_i16(int32_t());
+  from_i32_to_i16(uint32_t());
+
+#if HWY_HAVE_INTEGER64
+  const ForDemoteVectors<TestMaskedDemoteToInt<uint16_t>, 2>
+      from_i64_to_u16;
+  from_i64_to_u16(int64_t());
+  from_i64_to_u16(uint64_t());
+
+  const ForDemoteVectors<TestMaskedDemoteToInt<int16_t>, 2>
+      from_i64_to_i16;
+  from_i64_to_i16(int64_t());
+  from_i64_to_i16(uint64_t());
+
+  const ForDemoteVectors<TestMaskedDemoteToInt<uint32_t>> from_i64_to_u32;
+  from_i64_to_u32(int64_t());
+  from_i64_to_u32(uint64_t());
+
+  const ForDemoteVectors<TestMaskedDemoteToInt<int32_t>> from_i64_to_i32;
+  from_i64_to_i32(int64_t());
+  from_i64_to_i32(uint64_t());
+#endif
+}
+
+template <typename ToT>
 struct TestDemoteToFloat {
   template <typename T, class D>
   HWY_NOINLINE void operator()(T /*unused*/, D from_d) {
@@ -465,6 +566,107 @@ AlignedFreeUniquePtr<float[]> ReorderBF16TestCases(D d, size_t& padded) {
   CopyBytes(test_cases, in.get(), kNumTestCases * sizeof(float));
   ZeroBytes(in.get() + kNumTestCases, (padded - kNumTestCases) * sizeof(float));
   return in;
+}
+
+template <typename ToT>
+struct TestDemoteRoundFloatToFloat {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D from_d) {
+    static_assert(sizeof(T) > sizeof(ToT), "Input type must be wider");
+    const Rebind<ToT, D> to_d;
+
+    const size_t N = Lanes(from_d);
+    auto from = AllocateAligned<T>(N);
+    auto expected_ceil = AllocateAligned<ToT>(N);
+    auto expected_floor = AllocateAligned<ToT>(N);
+    HWY_ASSERT(from && expected_ceil && expected_floor);
+
+    RandomState rng;
+    for (size_t rep = 0; rep < AdjustedReps(1000); ++rep) {
+      for (size_t i = 0; i < N; ++i) {
+        const uint64_t bits = rng();
+        CopyBytes<sizeof(T)>(&bits, &from[i]);  // not same size
+        expected_ceil[i] = static_cast<ToT>(std::ceil(from[i]));
+        expected_floor[i] = static_cast<ToT>(std::floor(from[i]));
+      }
+      const auto in = Load(from_d, from.get());
+      HWY_ASSERT_VEC_EQ(to_d, expected_ceil.get(), DemoteCeilTo(to_d, in));
+      HWY_ASSERT_VEC_EQ(to_d, expected_floor.get(), DemoteFloorTo(to_d, in));
+    }
+  }
+};
+
+template <typename ToT>
+struct TestDemoteRoundFloatToInt {
+  template <typename T, class D>
+  HWY_NOINLINE void operator()(T /*unused*/, D from_d) {
+    static_assert(!IsFloat<ToT>(), "Use TestDemoteToFloat for float output");
+    static_assert(sizeof(T) > sizeof(ToT), "Input type must be wider");
+    const Rebind<ToT, D> to_d;
+
+    const size_t N = Lanes(from_d);
+    auto from = AllocateAligned<T>(N);
+    auto from_ceil = AllocateAligned<T>(N);
+    auto from_floor = AllocateAligned<T>(N);
+    auto expected_ceil = AllocateAligned<ToT>(N);
+    auto expected_floor = AllocateAligned<ToT>(N);
+    HWY_ASSERT(from && from_ceil && from_floor && expected_ceil &&
+               expected_floor);
+
+    // Narrower range in the wider type, for clamping before we cast
+    const T min = ConvertScalarTo<T>(IsSigned<T>() ? LimitsMin<ToT>()
+                                                   : static_cast<ToT>(0));
+    const T max = LimitsMax<ToT>();
+
+    RandomState rng;
+    for (size_t rep = 0; rep < AdjustedReps(1000); ++rep) {
+      for (size_t i = 0; i < N; ++i) {
+        const uint64_t bits = rng();
+        CopyBytes<sizeof(T)>(&bits, &from[i]);  // not same size
+        expected_ceil[i] =
+            static_cast<ToT>(std::ceil((HWY_MIN(HWY_MAX(min, from[i]), max))));
+        expected_floor[i] =
+            static_cast<ToT>(std::floor((HWY_MIN(HWY_MAX(min, from[i]), max))));
+      }
+      const auto in = Load(from_d, from.get());
+      HWY_ASSERT_VEC_EQ(to_d, expected_ceil.get(), DemoteCeilTo(to_d, in));
+      HWY_ASSERT_VEC_EQ(to_d, expected_floor.get(), DemoteFloorTo(to_d, in));
+    }
+
+    for (size_t rep = 0; rep < AdjustedReps(1000); ++rep) {
+      for (size_t i = 0; i < N; ++i) {
+        const uint64_t bits = rng();
+        CopyBytes<sizeof(ToT)>(&bits, &expected_ceil[i]);   // not same size
+        CopyBytes<sizeof(ToT)>(&bits, &expected_floor[i]);  // not same size
+
+        if (!IsSigned<T>() && IsSigned<ToT>()) {
+          expected_ceil[i] &= static_cast<ToT>(std::ceil((max)));
+          expected_floor[i] &= static_cast<ToT>(std::floor((max)));
+        }
+
+        from_ceil[i] = ConvertScalarTo<T>(expected_ceil[i]);
+        from_floor[i] = ConvertScalarTo<T>(expected_floor[i]);
+      }
+
+      const auto in_ceil = Load(from_d, from_ceil.get());
+      const auto in_floor = Load(from_d, from_floor.get());
+      HWY_ASSERT_VEC_EQ(to_d, expected_ceil.get(), DemoteCeilTo(to_d, in_ceil));
+      HWY_ASSERT_VEC_EQ(to_d, expected_floor.get(),
+                        DemoteFloorTo(to_d, in_floor));
+    }
+  }
+};
+
+HWY_NOINLINE void TestAllDemoteRoundTo() {
+#if HWY_HAVE_FLOAT64
+  const ForDemoteVectors<TestDemoteRoundFloatToInt<int32_t>> to_i32;
+  to_i32(double());
+#endif
+
+#if HWY_HAVE_FLOAT16
+  const ForDemoteVectors<TestDemoteRoundFloatToFloat<hwy::float16_t>> to_f16;
+  to_f16(float());
+#endif
 }
 
 class TestReorderDemote2To {
@@ -834,10 +1036,12 @@ namespace {
 #if !HWY_IS_MSAN
 HWY_BEFORE_TEST(HwyDemoteTest);
 HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllDemoteToInt);
+HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllMaskedDemoteToInt);
 HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllDemoteToMixed);
 HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllDemoteToFloat);
 HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllDemoteUI64ToFloat);
 HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllDemoteToBF16);
+HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllDemoteRoundTo);
 HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllReorderDemote2To);
 HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllOrderedDemote2To);
 HWY_EXPORT_AND_TEST_P(HwyDemoteTest, TestAllI32F64);


### PR DESCRIPTION
This contains the collection of operations where an SVE operation more optimal than the generic implementation was not found. As such, these have not been upstreamed into Google Highway currently and should be upstreamed  as part of the work to add x86 implementations.

Tests and documentation have been introduced for all the included operations.